### PR TITLE
Pip 987 add functions for caper croo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 [![CircleCI](https://circleci.com/gh/ENCODE-DCC/autouri.svg?style=svg)](https://circleci.com/gh/ENCODE-DCC/autouri)
 
+> **IMPORTANT**: If you use `--use-gsutil-for-s3` or `GCSURI.USE_GSUTIL_FOR_S3` then you need to update your `gsutil`. This flag allows a direct transfer between `gs://` and `s3://`. This requires `gsutil` >= 4.47. See this [issue](https://github.com/GoogleCloudPlatform/gsutil/issues/935) for details.
+```bash
+$ pip install gsutil --upgrade
+```
+
 # Autouri
 
 ## Introduction

--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -120,7 +120,8 @@ def main():
 
     elif args.action == 'cp':
         u_src = AutoURI(src)
-        _, flag = u_src.cp(target, make_md5_file=args.make_md5_file)
+        _, flag = u_src.cp(
+            target, make_md5_file=args.make_md5_file, return_flag=True)
 
         if flag == 0:
             logger.info('Copying from file {s} to {t} done'.format(

--- a/autouri/abspath.py
+++ b/autouri/abspath.py
@@ -106,8 +106,17 @@ class AbsPath(URIBase):
     def _cp_from(self, src_uri):
         return False
 
-    def get_mapped_url(self) -> Optional[str]:
-        for k, v in AbsPath.MAP_PATH_TO_URL.items():
+    def get_mapped_url(self, map_path_to_url=None) -> Optional[str]:
+        """
+        Args:
+            map_path_to_url:
+                dict with k, v where k is a path prefix and v is a URL prefix
+                k will be replaced with v.
+                If not given, defaults to use class constant AbsPath.MAP_PATH_TO_URL
+        """
+        if map_path_to_url is None:
+            map_path_to_url = AbsPath.MAP_PATH_TO_URL
+        for k, v in map_path_to_url.items():
             if k and self._uri.startswith(k):
                 return self._uri.replace(k, v, 1)
         return None

--- a/autouri/abspath.py
+++ b/autouri/abspath.py
@@ -138,21 +138,22 @@ class AbsPath(URIBase):
         If target already exists delete it and create a link.
 
         Args:
-            target: target file absolute path.
+            target:
+                Target file's absolute path or URI object.
+            force:
+                Delete target file (or link) if it exists
         """
         target = AbsPath(target)
         if not target.is_valid:
             raise ValueError('Target path is not a valid abs path: {t}.'.format(
                 t=target.uri))
         try:
+            target.mkdir_dirname()
             os.symlink(self._uri, target._uri)
         except OSError as e:
-            if e.errno == errno.EEXIST:
-                if force:
-                    target.rm()
-                    os.symlink(self._uri, target._uri)
-                else:
-                    raise e
+            if e.errno == errno.EEXIST and force:
+                target.rm()
+                os.symlink(self._uri, target._uri)
             else:
                 raise e
 

--- a/autouri/abspath.py
+++ b/autouri/abspath.py
@@ -178,6 +178,15 @@ class AbsPath(URIBase):
         return hash_md5.hexdigest()
 
     @staticmethod
+    def get_abspath_if_exists(path):
+        if isinstance(path, URIBase):
+            path = path._uri
+        if isinstance(path, str):
+            if os.path.exists(os.path.expanduser(path)):
+                return os.path.abspath(os.path.expanduser(path))
+        return path
+
+    @staticmethod
     def init_abspath(
         loc_prefix: Optional[str]=None,
         map_path_to_url: Optional[Dict[str, str]]=None,

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -10,7 +10,7 @@ from .loc_aux import recurse_json, recurse_tsv, recurse_csv
 from .metadata import URIMetadata
 
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s|%(name)s|%(levelname)s|%(message)s')
 logger = logging.getLogger('autouri')
 logger_filelock().setLevel(logging.CRITICAL)
 

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -273,7 +273,7 @@ class URIBase(ABC):
                     raise Exception(
                         'cp failed. src: {s} dest: {d}'.format(
                             s=str(self), d=str(d)))
-        return d, 0
+        return d._uri, 0
 
     def write(self, s, no_lock=False):
         """Write string/bytes to file. It is protected by a locking mechanism.

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -233,7 +233,9 @@ class URIBase(ABC):
                 hash then md5 file will not be created.
 
         Returns:
-            Tuple of (copy on destination, rc)
+            Tuple of (s, rc)
+                s:
+                    URI string of copy on destination
                 rc:
                     0:
                         made a copy

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -10,7 +10,7 @@ from .loc_aux import recurse_json, recurse_tsv, recurse_csv
 from .metadata import URIMetadata
 
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s|%(name)s|%(levelname)s|%(message)s')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s|%(name)s|%(levelname)s| %(message)s')
 logger = logging.getLogger('autouri')
 logger_filelock().setLevel(logging.CRITICAL)
 

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -89,6 +89,8 @@ class GCSURI(URIBase):
             GCS client is not thread-safe.
         _CACHED_PRESIGNED_URLS:
             Can use cached presigned URLs.
+        _GCS_PUBLIC_URL_FORMAT:
+            End point for a bucket with public access + key path
     """
     PRIVATE_KEY_FILE: str = ''
     DURATION_PRESIGNED_URL: int = 4233600
@@ -99,6 +101,7 @@ class GCSURI(URIBase):
 
     _CACHED_GCS_CLIENT_PER_THREAD = {}
     _CACHED_PRESIGNED_URLS = {}
+    _GCS_PUBLIC_URL_FORMAT = 'http://storage.googleapis.com/{bucket}/{path}'
 
     _LOC_SUFFIX = '.gcs'
     _SCHEMES = ('gs://',)
@@ -327,6 +330,10 @@ class GCSURI(URIBase):
             credentials=credentials)
         cache[self._uri] = url
         return url
+
+    def get_public_url(self) -> str:
+        bucket, path = self.get_bucket_path()
+        return GCSURI._GCS_PUBLIC_URL_FORMAT.format(bucket=bucket, path=path)
 
     @staticmethod
     def get_gcs_client(thread_id) -> storage.Client:

--- a/autouri/loc_aux.py
+++ b/autouri/loc_aux.py
@@ -34,7 +34,7 @@ def recurse_json(contents: str, fnc: Callable) -> Tuple[str, bool]:
         elif isinstance(d, list):
             for i, v in enumerate(d):
                 modified |= recurse_dict(v, fnc, lst=d,
-                                         slst_idx=i, modified=modified)
+                                         lst_idx=i, modified=modified)
         elif isinstance(d, str):
             assert(d_parent is not None or lst is not None)
             new_val, modified_ = fnc(d)

--- a/autouri/s3uri.py
+++ b/autouri/s3uri.py
@@ -75,11 +75,14 @@ class S3URI(URIBase):
     Protected class constants:
         _CACHED_BOTO3_CLIENT_PER_THREAD:
         _CACHED_PRESIGNED_URLS:
+        _S3_PUBLIC_URL_FORMAT:
+            End point for a bucket with public access + key path
     """
     DURATION_PRESIGNED_URL: int = 4233600
 
     _CACHED_BOTO3_CLIENT_PER_THREAD = {}
     _CACHED_PRESIGNED_URLS = {}
+    _S3_PUBLIC_URL_FORMAT = 'http://{bucket}.s3.amazonaws.com/{path}'
 
     _LOC_SUFFIX = '.s3'
     _SCHEMES = ('s3://',)
@@ -248,6 +251,10 @@ class S3URI(URIBase):
             ExpiresIn=duration)
         cache[self._uri] = url
         return url
+
+    def get_public_url(self) -> str:
+        bucket, path = self.get_bucket_path()
+        return S3URI._S3_PUBLIC_URL_FORMAT.format(bucket=bucket, path=path)
 
     @staticmethod
     def get_boto3_client(thread_id=-1) -> client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,17 @@ def pytest_addoption(parser):
         '--s3-root', default='s3://encode-test-autouri/tmp',
         help='S3 root path for CI test. '
              'This S3 bucket must be configured without versioning. '
-             'Also, it must be publicly accessible '
-             '(read access for everyone is enough for testing).'
+             'Make it publicly accessible. '
+             'Read access for everyone is enough for testing. '
+    )
+    parser.addoption(
+        '--s3-public-url-test-v6-file', default='s3://encode-test-autouri/tmp/v6.txt',
+        help='Write "v6: Hello World" to this file named "v6.txt" '
+             'and grant "Read object" permission on it. '
+             'Since S3 object does not inherit ACL from bucket/parent '
+             'and S3URI does not have methods to control ACL of an object '
+             'so this is the only way to test get_public_url(self) method in '
+             'S3URI.'
     )
     parser.addoption(
         '--gcs-root', default='gs://encode-test-autouri/tmp',
@@ -66,6 +75,11 @@ def s3_root(request):
     """S3 root to generate test S3 URIs on.
     """
     return request.config.getoption("--s3-root").rstrip('/')
+
+
+@pytest.fixture(scope="session")
+def s3_public_url_test_v6_file(request):
+    return request.config.getoption("--s3-public-url-test-v6-file")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,11 +31,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--s3-root', default='s3://encode-test-autouri/tmp',
         help='S3 root path for CI test. '
-             'This S3 bucket must be configured without versioning.'
+             'This S3 bucket must be configured without versioning. '
+             'Also, it must be publicly accessible '
+             '(read access for everyone is enough for testing).'
     )
     parser.addoption(
         '--gcs-root', default='gs://encode-test-autouri/tmp',
         help='GCS root path for CI test. '
+             'This GCS bucket must be publicly accessible '
+             '(read access for everyone is enough for testing).'
     )
     parser.addoption(
         '--gcs-root-url', default='gs://encode-test-autouri/tmp_url',

--- a/tests/test_abspath.py
+++ b/tests/test_abspath.py
@@ -401,6 +401,7 @@ def test_abspath_localize(
         loc_uri, localized = AbsPath.localize(
             u_j1_json,
             recursive=False,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == u_j1_json.uri and not localized
         assert not os.path.exists(loc_prefix)
@@ -408,6 +409,7 @@ def test_abspath_localize(
         loc_uri, localized = AbsPath.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == u_j1_json.uri and not localized
         assert not os.path.exists(loc_prefix)
@@ -422,6 +424,7 @@ def test_abspath_localize(
         loc_uri, localized = AbsPath.localize(
             u_j1_json,
             recursive=False,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == os.path.join(
             loc_prefix_, u_j1_json.loc_dirname,
@@ -431,6 +434,7 @@ def test_abspath_localize(
         loc_uri, localized = AbsPath.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == os.path.join(
             loc_prefix_, u_j1_json.loc_dirname,

--- a/tests/test_abspath.py
+++ b/tests/test_abspath.py
@@ -315,6 +315,32 @@ def test_abspath_soft_link(local_test_path, local_v6_txt):
     u_target.rm()
 
 
+# staticmethods
+def test_abspath_get_abspath_if_exists():
+    # write a local file on CWD.
+    test_local_file_abspath = os.path.join(os.getcwd(), 'test.txt')
+    u = AbsPath(test_local_file_abspath)
+    if u.exists:
+        u.rm()
+
+    # if it doesn't exist
+    assert AbsPath.get_abspath_if_exists('test.txt') == 'test.txt'
+    assert AbsPath.get_abspath_if_exists(AutoURI('test.txt')) == 'test.txt'
+
+    u.write('hello-world')
+
+    # if it exists
+    assert AbsPath.get_abspath_if_exists('test.txt') == test_local_file_abspath
+    assert AbsPath.get_abspath_if_exists(AutoURI('test.txt')) == test_local_file_abspath
+
+    assert AbsPath.get_abspath_if_exists('tttttttttest.txt') == 'tttttttttest.txt'
+    assert AbsPath.get_abspath_if_exists(AutoURI('tttttttttest.txt')) == 'tttttttttest.txt'
+    assert AbsPath.get_abspath_if_exists('~/if-it-does-not-exist') == '~/if-it-does-not-exist'
+    assert AbsPath.get_abspath_if_exists('non-existing-file') == 'non-existing-file'
+
+    u.rm()
+
+
 # classmethods
 def test_abspath_get_path_sep() -> str:
     assert AbsPath.get_path_sep() == os.path.sep

--- a/tests/test_abspath.py
+++ b/tests/test_abspath.py
@@ -134,7 +134,7 @@ def test_abspath_cp_url(
     for test_path in (url_test_path, ):
         u_dest = AutoURI(os.path.join(test_path, 'test_abspath_cp', basename))
         with pytest.raises(ReadOnlyStorageError):
-            _, ret = u.cp(u_dest)
+            _, ret = u.cp(u_dest, return_flag=True)
 
 
 def test_abspath_cp(
@@ -167,26 +167,26 @@ def test_abspath_cp(
             u_dest.rm()
 
         assert not u_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         assert not u_dest.exists
         # cp without lock will be tested throughly in test_race_cond.py
-        _, ret = u.cp(u_dest, no_lock=True)
+        _, ret = u.cp(u_dest, no_lock=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         # trivial: copy without checksum when target doesn't exists
         assert not u_dest.exists
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
 
         # copy without checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
         time.sleep(1)
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be larger if it's overwritten as intended        
         assert u_dest.mtime > m_dest.mtime and u.read() == u_dest.read() and ret == 0
@@ -194,7 +194,7 @@ def test_abspath_cp(
         # copy with checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be the same as old time
         assert u_dest.mtime == m_dest.mtime and u.read() == u_dest.read() and ret == 1
@@ -207,7 +207,7 @@ def test_abspath_cp(
         u_dest_md5_file = AutoURI(u_dest.uri + URIBase.MD5_FILE_EXT)
         if u_dest_md5_file.exists:
             u_dest_md5_file.rm()
-        _, ret = u.cp(u_dest, make_md5_file=True)
+        _, ret = u.cp(u_dest, make_md5_file=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 1
         u_dest.rm()
 

--- a/tests/test_abspath.py
+++ b/tests/test_abspath.py
@@ -298,6 +298,23 @@ def test_abspath_mkdirname(local_test_path):
     assert os.path.exists(os.path.dirname(f))
 
 
+def test_abspath_soft_link(local_test_path, local_v6_txt):
+    u_src = AbsPath(local_v6_txt)
+    f = os.path.join(local_test_path, 'test_abspath_soft_link', 'v6.txt')
+    u_target = AbsPath(f)
+    u_target.mkdir_dirname()
+    u_src.soft_link(u_target)
+    assert u_target.exists and u_target.read() == v6_txt_contents()
+    assert u_src.uri == os.path.realpath(u_target.uri)
+
+    with pytest.raises(OSError):
+        # file already exists
+        u_src.soft_link(u_target)
+    # no error if force
+    u_src.soft_link(u_target, force=True)
+    u_target.rm()
+
+
 # classmethods
 def test_abspath_get_path_sep() -> str:
     assert AbsPath.get_path_sep() == os.path.sep

--- a/tests/test_autouri_localize.py
+++ b/tests/test_autouri_localize.py
@@ -70,6 +70,7 @@ def test_localize_mixed(
         loc_uri, localized = AbsPath.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         # check if all URIs defeind in localized JSON file exist
         recurse_raise_if_uri_not_exist(loc_uri)

--- a/tests/test_gcsuri.py
+++ b/tests/test_gcsuri.py
@@ -406,6 +406,7 @@ def test_gcsuri_localize(
         loc_uri, localized = GCSURI.localize(
             u_j1_json,
             recursive=False,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == u_j1_json.uri and not localized
         assert not AutoURI(os.path.join(loc_prefix_, basename)).exists
@@ -413,6 +414,7 @@ def test_gcsuri_localize(
         loc_uri, localized = GCSURI.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == u_j1_json.uri and not localized
         assert not AutoURI(os.path.join(loc_prefix_, basename)).exists
@@ -428,6 +430,7 @@ def test_gcsuri_localize(
         loc_uri, localized = GCSURI.localize(
             u_j1_json,
             recursive=False,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         expected = os.path.join(
             loc_prefix_, u_j1_json.loc_dirname,
@@ -438,6 +441,7 @@ def test_gcsuri_localize(
         loc_uri, localized = GCSURI.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         expected = os.path.join(
             loc_prefix_, u_j1_json.loc_dirname,

--- a/tests/test_gcsuri.py
+++ b/tests/test_gcsuri.py
@@ -312,6 +312,12 @@ def test_gcsuri_get_presigned_url(gcs_v6_txt, gcp_private_key_file):
     # assert u_url.read() != v6_txt_contents()
 
 
+def test_gcsuri_get_public_url(gcs_v6_txt):
+    url = GCSURI(gcs_v6_txt).get_public_url()
+    u_url = HTTPURL(url)
+    assert u_url.is_valid and u_url.read() == v6_txt_contents()
+
+
 # classmethods
 def test_gcsuri_get_path_sep() -> str:
     assert GCSURI.get_path_sep() == os.path.sep

--- a/tests/test_gcsuri.py
+++ b/tests/test_gcsuri.py
@@ -139,7 +139,7 @@ def test_gcsuri_cp_url(
     for test_path in (url_test_path,):
         u_dest = AutoURI(os.path.join(test_path, 'test_gcsuri_cp', basename))
         with pytest.raises(ReadOnlyStorageError):
-            _, ret = u.cp(u_dest)
+            _, ret = u.cp(u_dest, return_flag=True)
 
 
 def test_gcsuri_cp(
@@ -171,26 +171,26 @@ def test_gcsuri_cp(
             u_dest.rm()
 
         assert not u_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         assert not u_dest.exists
         # cp without lock will be tested throughly in test_race_cond.py
-        _, ret = u.cp(u_dest, no_lock=True)
+        _, ret = u.cp(u_dest, no_lock=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         # trivial: copy without checksum when target doesn't exists
         assert not u_dest.exists
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
 
         # copy without checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
         time.sleep(1)
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be larger if it's overwritten as intended        
         assert u_dest.mtime > m_dest.mtime and u.read() == u_dest.read() and ret == 0
@@ -198,7 +198,7 @@ def test_gcsuri_cp(
         # copy with checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be the same as old time
         assert u_dest.mtime == m_dest.mtime and u.read() == u_dest.read() and ret == 1
@@ -211,7 +211,7 @@ def test_gcsuri_cp(
         u_dest_md5_file = AutoURI(u_dest.uri + URIBase.MD5_FILE_EXT)
         if u_dest_md5_file.exists:
             u_dest_md5_file.rm()
-        _, ret = u.cp(u_dest, make_md5_file=True)
+        _, ret = u.cp(u_dest, make_md5_file=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 1
         u_dest.rm()
 

--- a/tests/test_httpurl.py
+++ b/tests/test_httpurl.py
@@ -191,26 +191,26 @@ def test_httpurl_cp(
             u_dest.rm()
 
         assert not u_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         assert not u_dest.exists
         # cp without lock will be tested throughly in test_race_cond.py
-        _, ret = u.cp(u_dest, no_lock=True)
+        _, ret = u.cp(u_dest, no_lock=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         # trivial: copy without checksum when target doesn't exists
         assert not u_dest.exists
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
 
         # copy without checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
         time.sleep(1)
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be larger if it's overwritten as intended        
         assert u_dest.mtime > m_dest.mtime and u.read() == u_dest.read() and ret == 0
@@ -218,7 +218,7 @@ def test_httpurl_cp(
         # copy with checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be the same as old time
         assert u_dest.mtime == m_dest.mtime and u.read() == u_dest.read() and ret == 1
@@ -231,7 +231,7 @@ def test_httpurl_cp(
         u_dest_md5_file = AutoURI(u_dest.uri + URIBase.MD5_FILE_EXT)
         if u_dest_md5_file.exists:
             u_dest_md5_file.rm()
-        _, ret = u.cp(u_dest, make_md5_file=True)
+        _, ret = u.cp(u_dest, make_md5_file=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 1
         u_dest.rm()
 

--- a/tests/test_httpurl.py
+++ b/tests/test_httpurl.py
@@ -159,7 +159,7 @@ def test_httpurl_cp_url(
         u_dest = AutoURI(os.path.join(test_path, 'test_httpurl_cp', basename))
 
         with pytest.raises(ReadOnlyStorageError):
-            _, ret = u.cp(u_dest)
+            _, ret = u.cp(u_dest, return_flag=True)
 
 
 def test_httpurl_cp(

--- a/tests/test_httpurl.py
+++ b/tests/test_httpurl.py
@@ -236,16 +236,16 @@ def test_httpurl_cp(
         u_dest.rm()
 
 
-@pytest.mark.xfail(raises=ReadOnlyStorageError)
 def test_httpurl_write(url_test_path):
     u = HTTPURL(url_test_path + '/test_httpurl_write.tmp')
-    u.write('test')
+    with pytest.raises(ReadOnlyStorageError):
+        u.write('test')
 
 
-@pytest.mark.xfail(raises=ReadOnlyStorageError)
 def test_httpurl_rm(url_test_path):
     u = HTTPURL(url_test_path + '/test_httpurl_rm.tmp')
-    u.rm()
+    with pytest.raises(ReadOnlyStorageError):
+        u.rm()
 
 
 def test_httpurl_get_metadata(url_v6_txt, v6_txt_size, v6_txt_md5_hash):
@@ -297,7 +297,6 @@ def test_httpurl_get_loc_prefix() -> str:
     assert HTTPURL.get_loc_prefix() == ''
 
 
-@pytest.mark.xfail(raises=ReadOnlyStorageError)
 def test_httpurl_localize(
         url_test_path,
         gcs_j1_json, gcs_v41_json, gcs_v421_tsv, gcs_v5_csv, gcs_v6_txt,
@@ -316,7 +315,8 @@ def test_httpurl_localize(
         # nothing should be localized actually
         # since they are already on a local storage
         # so loc_prefix directory itself shouldn't be created
-        loc_uri, localized = HTTPURL.localize(
-            u_j1_json,
-            recursive=False,
-            loc_prefix=loc_prefix_)
+        with pytest.raises(ReadOnlyStorageError):
+            loc_uri, localized = HTTPURL.localize(
+                u_j1_json,
+                recursive=False,
+                loc_prefix=loc_prefix_)

--- a/tests/test_s3uri.py
+++ b/tests/test_s3uri.py
@@ -393,6 +393,7 @@ def test_s3uri_localize(
         loc_uri, localized = S3URI.localize(
             u_j1_json,
             recursive=False,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == u_j1_json.uri and not localized
         assert not AutoURI(os.path.join(loc_prefix_, basename)).exists
@@ -400,6 +401,7 @@ def test_s3uri_localize(
         loc_uri, localized = S3URI.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         assert loc_uri == u_j1_json.uri and not localized
         assert not AutoURI(os.path.join(loc_prefix_, basename)).exists
@@ -415,6 +417,7 @@ def test_s3uri_localize(
         loc_uri, localized = S3URI.localize(
             u_j1_json,
             recursive=False,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         expected = os.path.join(
             loc_prefix_, u_j1_json.loc_dirname,
@@ -425,6 +428,7 @@ def test_s3uri_localize(
         loc_uri, localized = S3URI.localize(
             u_j1_json,
             recursive=True,
+            return_flag=True,
             loc_prefix=loc_prefix_)
         expected = os.path.join(
             loc_prefix_, u_j1_json.loc_dirname,

--- a/tests/test_s3uri.py
+++ b/tests/test_s3uri.py
@@ -299,6 +299,12 @@ def test_s3uri_get_presigned_url(s3_v6_txt):
         s = u_url.read()
 
 
+def test_s3uri_get_public_url(s3_v6_txt):
+    url = S3URI(s3_v6_txt).get_public_url()
+    u_url = HTTPURL(url)
+    assert u_url.is_valid and u_url.read() == v6_txt_contents()
+
+
 # classmethods
 def test_s3uri_get_path_sep() -> str:
     assert S3URI.get_path_sep() == os.path.sep

--- a/tests/test_s3uri.py
+++ b/tests/test_s3uri.py
@@ -299,10 +299,11 @@ def test_s3uri_get_presigned_url(s3_v6_txt):
         s = u_url.read()
 
 
-def test_s3uri_get_public_url(s3_v6_txt):
-    url = S3URI(s3_v6_txt).get_public_url()
+def test_s3uri_get_public_url(s3_public_url_test_v6_file):
+    url = S3URI(s3_public_url_test_v6_file).get_public_url()
     u_url = HTTPURL(url)
-    assert u_url.is_valid and u_url.read() == v6_txt_contents()
+    assert u_url.is_valid
+    assert u_url.read() == v6_txt_contents()
 
 
 # classmethods

--- a/tests/test_s3uri.py
+++ b/tests/test_s3uri.py
@@ -141,7 +141,7 @@ def test_s3uri_cp_url(
         u_dest = AutoURI(os.path.join(test_path, 'test_s3uri_cp', basename))
 
         with pytest.raises(ReadOnlyStorageError):
-            _, ret = u.cp(u_dest)
+            _, ret = u.cp(u_dest, return_flag=True)
 
 
 def test_s3uri_cp(
@@ -173,26 +173,26 @@ def test_s3uri_cp(
             u_dest.rm()
 
         assert not u_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         assert not u_dest.exists
         # cp without lock will be tested throughly in test_race_cond.py
-        _, ret = u.cp(u_dest, no_lock=True)
+        _, ret = u.cp(u_dest, no_lock=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
         u_dest.rm()
 
         # trivial: copy without checksum when target doesn't exists
         assert not u_dest.exists
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 0
 
         # copy without checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
         time.sleep(1)
-        _, ret = u.cp(u_dest, no_checksum=True)
+        _, ret = u.cp(u_dest, no_checksum=True, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be larger if it's overwritten as intended        
         assert u_dest.mtime > m_dest.mtime and u.read() == u_dest.read() and ret == 0
@@ -200,7 +200,7 @@ def test_s3uri_cp(
         # copy with checksum when target exists
         m_dest = u_dest.get_metadata()
         assert m_dest.exists
-        _, ret = u.cp(u_dest)
+        _, ret = u.cp(u_dest, return_flag=True)
         # compare new mtime vs old mtime
         # new time should be the same as old time
         assert u_dest.mtime == m_dest.mtime and u.read() == u_dest.read() and ret == 1
@@ -213,7 +213,7 @@ def test_s3uri_cp(
         u_dest_md5_file = AutoURI(u_dest.uri + URIBase.MD5_FILE_EXT)
         if u_dest_md5_file.exists:
             u_dest_md5_file.rm()
-        _, ret = u.cp(u_dest, make_md5_file=True)
+        _, ret = u.cp(u_dest, make_md5_file=True, return_flag=True)
         assert u_dest.exists and u.read() == u_dest.read() and ret == 1
         u_dest.rm()
 


### PR DESCRIPTION
Added:
- Soft-linking for local paths (`AbsPath`)
- Converting relative path into abs path (`AbsPath.get_abspath_if_exists()`)
  - `AbsPath` only allows absolute path as its name says. so added a helper function for such conversion so that apps using Autouri can use it.
- Detailed logging (INFO, DEBUG)
- Can hide flag for `AutoURI.cp()` and `AutoURI.localize()` (`return_flag=False`).
- Can get URL from public GCS/S3 bucket (without presigning)
  - For `GCSURI`, `S3URI` only. Formatting for a public URL looks like the following:
    ```
     _GCS_PUBLIC_URL_FORMAT = 'http://storage.googleapis.com/{bucket}/{path}'
    _S3_PUBLIC_URL_FORMAT = 'http://{bucket}.s3.amazonaws.com/{path}'
    ```
  - This is different from a presigned URL. It's for a file on a bucket with public access. If users use this function on a private bucket file then this function will still return a URL but public access to this URL will be limited (403).

Bug fixes
- `SameFileError` while soft-linking
- Better logging format
- Replaced `pytest`'s `xfail` with `pytest.raises` context.

Important notice
- To allow direct transfer between S3 and GCS, Autouri uses `gsutil` CLI. For this, `GCSURI.USE_GSUTIL_FOR_S3` flag must be on. Otherwise Autouri will stream file transfer through a local machine. Old `gsutil` had a py3 compatibility [issue](https://github.com/GoogleCloudPlatform/gsutil/issues/935). Users need to update `gsutil` to >= 4.47.