### PR TITLE
hotfix to lower python req ver

### DIFF
--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -10,7 +10,7 @@ from .s3uri import S3URI
 from .gcsuri import GCSURI
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 def parse_args():

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fh:
 setuptools.setup(
     name='autouri',
     version=autouri.__version__,
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     scripts=['bin/autouri'],
     author='Jin wook Lee',
     author_email='leepc12@gmail.com',


### PR DESCRIPTION
Lower required python version from `>=3.6` to `>=3.5`.