### PR TITLE
Hotfix pip

### DIFF
--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -113,26 +113,22 @@ def parse_args():
     return args
 
 
-def get_local_file_if_valid(s):
-    path = os.path.expanduser(s)
-    abspath = os.path.abspath(path)
-    dirname = os.path.dirname(abspath)
-
-    if os.path.exists(path) or os.path.exists(dirname):
-        trailing_slash = os.sep if s.endswith(os.sep) else ''
-        return abspath + trailing_slash
+def get_local_path_if_valid(s):
+    abspath = os.path.abspath(os.path.expanduser(s))
+    if os.path.isdir(abspath):
+        return abspath + os.sep
     return s
 
 
 def main():
     args = parse_args()
 
-    src = get_local_file_if_valid(args.src)
+    src = get_local_path_if_valid(args.src)
 
     if args.action in ('cp', 'loc'):
         if args.use_gsutil_for_s3:
             GCSURI.init_gcsuri(use_gsutil_for_s3=True)
-        target = get_local_file_if_valid(args.target)
+        target = get_local_path_if_valid(args.target)
 
     if args.action == 'metadata':
         m = AutoURI(src).get_metadata()

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -255,7 +255,6 @@ class URIBase(ABC):
         d = AutoURI(dest_uri)
         sep = d.__class__.get_path_sep()
         if d._uri.endswith(sep):
-            print(d._uri.rstrip(sep), sep, self.basename)
             d = AutoURI(sep.join([d._uri.rstrip(sep), self.basename]))
 
         with d.get_lock(no_lock=no_lock) as lock:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 import setuptools
-import autouri
+import pkg_resources
+
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name='autouri',
-    version=autouri.__version__,
+    version=pkg_resources.get_distribution('autouri').version,
     python_requires='>=3.6',
     scripts=['bin/autouri'],
     author='Jin wook Lee',


### PR DESCRIPTION
Fix importing self-package in `setup.py` by using `pkg_resources` instead.

Added parameters for CLI:
- `--debug` and `--verbose`: better logging.
- `--version`: prints out Autouri's version.

Bug fixes
- Better argparsing so that users can use `.` and `..` in CLI (e.g. `../../hello/world/..`).