### PR TITLE
v0.1.4

### DIFF
--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -5,4 +5,4 @@ from .gcsuri import GCSURI
 from .s3uri import S3URI
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -47,7 +47,7 @@ class GCSURILock(BaseFileLock):
                 blob.temporary_hold = True
                 blob.patch()
                 self._lock_file_fd = id(self)
-            except (GatewayTimeout, NotFound, ServiceUnavailable):
+            except (Forbidden, GatewayTimeout, NotFound, ServiceUnavailable):
                 pass
         return None
 

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -47,7 +47,7 @@ class GCSURILock(BaseFileLock):
                 blob.temporary_hold = True
                 blob.patch()
                 self._lock_file_fd = id(self)
-            except (Forbidden, GatewayTimeout, NotFound, ServiceUnavailable):
+            except (GatewayTimeout, NotFound, ServiceUnavailable):
                 pass
         return None
 

--- a/autouri/httpurl.py
+++ b/autouri/httpurl.py
@@ -106,7 +106,7 @@ class HTTPURL(URIBase):
             self._uri, stream=True, allow_redirects=True,
             headers=requests.utils.default_headers())
         r.raise_for_status()
-        b = r.raw.read()
+        b = r.content
         if byte:
             return b
         else:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='autouri',
-    version='0.1.3',
+    version='0.1.4',
     python_requires='>=3.6',
     scripts=['bin/autouri'],
     author='Jin wook Lee',


### PR DESCRIPTION
Bug fix for URL contents decoding
```
Traceback (most recent call last):
  File "/usr/local/bin/caper", line 13, in <module>
    main()
  File "/usr/local/lib/python3.6/dist-packages/caper/cli.py", line 58, in main
    c.submit()
  File "/usr/local/lib/python3.6/dist-packages/caper/caper.py", line 384, in submit
    imports_file = self.__create_imports_zip_file_from_wdl(tmp_dir)
  File "/usr/local/lib/python3.6/dist-packages/caper/caper.py", line 847, in __create_imports_zip_file_from_wdl
    if CaperWDLParser(self._wdl).zip_subworkflows(zip_file):
  File "/usr/local/lib/python3.6/dist-packages/caper/caper_wdl_parser.py", line 75, in zip_subworkflows
    root_zip_dir=tmp_d)
  File "/usr/local/lib/python3.6/dist-packages/caper/caper_wdl_parser.py", line 189, in __recurse_subworkflow
    depth=depth + 1)
  File "/usr/local/lib/python3.6/dist-packages/caper/caper_wdl_parser.py", line 146, in __recurse_subworkflow
    imports = self.find_imports()
  File "/usr/local/lib/python3.6/dist-packages/caper/caper_wdl_parser.py", line 39, in find_imports
    CaperWDLParser.RE_PATTERN_WDL_IMPORT)
  File "/usr/local/lib/python3.6/dist-packages/caper/caper_wdl_parser.py", line 85, in __find_val
    for line in u.read().split('\n'):
  File "/usr/local/lib/python3.6/dist-packages/autouri/httpurl.py", line 113, in read
    return b.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
```