### PR TITLE
v0.2.4

### DIFF
--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -5,4 +5,4 @@ from .httpurl import HTTPURL
 from .s3uri import S3URI
 
 __all__ = ["AbsPath", "AutoURI", "URIBase", "GCSURI", "HTTPURL", "S3URI"]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/autouri/abspath.py
+++ b/autouri/abspath.py
@@ -196,10 +196,17 @@ class AbsPath(URIBase):
     def __calc_md5sum(self):
         """Expensive md5 calculation
         """
+        logger.debug(
+            "calculating md5sum hash of local file: {file}".format(file=self._uri)
+        )
         hash_md5 = hashlib.md5()
         with open(self._uri, "rb") as fp:
             for chunk in iter(lambda: fp.read(AbsPath.MD5_CALC_CHUNK_SIZE), b""):
                 hash_md5.update(chunk)
+
+        logger.debug(
+            "calculating md5sum is done for local file: {file}".format(file=self._uri)
+        )
         return hash_md5.hexdigest()
 
     @staticmethod

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -394,6 +394,7 @@ class URIBase(ABC):
         return_flag=False,
         depth=0,
         no_lock=False,
+        no_checksum=False,
     ) -> Tuple[str, bool]:
         """Wrapper for classmethod localize().
         Localizes self on target directory loc_prefix.
@@ -406,6 +407,7 @@ class URIBase(ABC):
             return_flag=return_flag,
             depth=depth,
             no_lock=no_lock,
+            no_checksum=no_checksum,
         )
 
     @abstractmethod
@@ -521,6 +523,7 @@ class URIBase(ABC):
         return_flag=False,
         depth=0,
         no_lock=False,
+        no_checksum=False,
     ) -> Tuple[str, bool]:
         """Localize a source URI on this URI class (cls).
 
@@ -553,6 +556,8 @@ class URIBase(ABC):
                 To count recursion depth.
             no_lock:
                 No file locking.
+            no_checksum:
+                Do not check md5 hash.
         Returns:
             loc_uri:
                 Localized URI STRING (not a AutoURI instance) since it should be used
@@ -609,6 +614,7 @@ class URIBase(ABC):
                     return_flag=True,
                     depth=depth + 1,
                     no_lock=no_lock,
+                    no_checksum=no_checksum,
                 )
 
             for ext, fnc_recurse in AutoURI.LOC_RECURSE_EXT_AND_FNC.items():
@@ -632,7 +638,12 @@ class URIBase(ABC):
             dirname = src_uri.loc_dirname
 
             loc_uri = cls.get_path_sep().join([loc_prefix, dirname, basename])
-            src_uri.cp(dest_uri=loc_uri, make_md5_file=make_md5_file, no_lock=no_lock)
+            src_uri.cp(
+                dest_uri=loc_uri,
+                make_md5_file=make_md5_file,
+                no_lock=no_lock,
+                no_checksum=no_checksum,
+            )
         else:
             loc_uri = src_uri._uri
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="autouri",
-    version="0.2.3",
+    version="0.2.4",
     python_requires=">=3.6",
     scripts=["bin/autouri"],
     author="Jin wook Lee",


### PR DESCRIPTION
Fixed redundant md5sum hashing of a local temporary file.
- `no_checksum` was not propagated for a recursive localization of JSON/CSV/TSV files.
