### PR TITLE
Pip 1526 help to delete lock file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="autouri",
-    version="0.2.4",
+    version="0.2.5",
     python_requires=">=3.6",
     scripts=["bin/autouri"],
     author="Jin wook Lee",


### PR DESCRIPTION
Added help to manually delete a lock file.
```
2021-04-12 14:36:54,941|autouri.gcsuri|ERROR| Filelock timed out. Is there any other process holding the file? Or this can happen when autouri was forcefully killed while holding a file. e.g. pressing Ctrl+C two many times or killed by the system with SIGKILL. If there is no other process holding the file then please manually release/delete the lock file with gsutil. Use the following command lines to delete the lock file.

gsutil retention temp release gs://encode-processing/test_lock_file/README.md.lock
gsutil rm gs://encode-processing/test_lock_file/README.md.lock

Traceback (most recent call last):
  File "/software/miniconda3/bin/autouri", line 13, in <module>
    main()
  File "/users/leepc12/code/autouri/autouri/cli.py", line 199, in main
    no_lock=args.no_lock,
  File "/users/leepc12/code/autouri/autouri/autouri.py", line 282, in cp
    with d.get_lock(no_lock=no_lock):
  File "/software/miniconda3/lib/python3.6/site-packages/filelock.py", line 323, in __enter__
    self.acquire()
  File "/users/leepc12/code/autouri/autouri/gcsuri.py", line 103, in acquire
    super().acquire(timeout=timeout, poll_intervall=self._poll_interval)
  File "/software/miniconda3/lib/python3.6/site-packages/filelock.py", line 278, in acquire
    raise Timeout(self._lock_file)
filelock.Timeout: The file lock 'gs://encode-processing/test_lock_file/README.md.lock' could not be acquired.
```