### PR TITLE
v0.2.6

### DIFF
--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -5,4 +5,4 @@ from .httpurl import HTTPURL
 from .s3uri import S3URI
 
 __all__ = ["AbsPath", "AutoURI", "URIBase", "GCSURI", "HTTPURL", "S3URI"]
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/autouri/autouri.py
+++ b/autouri/autouri.py
@@ -345,12 +345,13 @@ class URIBase(ABC):
             self._write(s)
         return
 
-    def rm(self, no_lock=False):
+    def rm(self, no_lock=False, silent=False):
         """Remove a URI from its storage. It is protected by by a locking mechanism.
         """
         with self.get_lock(no_lock=no_lock):
             self._rm()
-            logger.info("rm: {uri}".format(uri=self._uri))
+            if not silent:
+                logger.info("rm: {uri}".format(uri=self._uri))
         return
 
     def rmdir(self, dry_run=False, num_threads=DEFAULT_NUM_THREADS, no_lock=False):

--- a/autouri/s3uri.py
+++ b/autouri/s3uri.py
@@ -61,7 +61,7 @@ class S3URILock(BaseFileLock):
     def _release(self):
         u = S3URI(self._lock_file)
         try:
-            u.rm(no_lock=True)
+            u.rm(no_lock=True, silent=True)
             self._lock_file_fd = None
         except ClientError:
             pass

--- a/autouri/s3uri.py
+++ b/autouri/s3uri.py
@@ -75,6 +75,8 @@ class S3URI(URIBase):
             Path prefix for localization. Inherited from URIBase class.
         DURATION_PRESIGNED_URL:
             Duration for presigned URLs in seconds.
+        S3_COPY_OBJECT_FILE_SIZE_LIMIT:
+            File size limit (in bytes) for S3 copy_object (for s3 to s3 transfer).
 
     Protected class constants:
         _CACHED_BOTO3_CLIENTS:
@@ -84,6 +86,7 @@ class S3URI(URIBase):
     """
 
     DURATION_PRESIGNED_URL: int = 4233600
+    S3_COPY_OBJECT_FILE_SIZE_LIMIT: int = 5 * 1024 * 1024 * 1024
 
     _CACHED_BOTO3_CLIENTS = {}
     _CACHED_PRESIGNED_URLS = {}
@@ -196,7 +199,12 @@ class S3URI(URIBase):
 
         if isinstance(dest_uri, S3URI):
             dest_bucket, dest_path = dest_uri.get_bucket_path()
-            cl.copy_object(
+
+            if self.size >= S3URI.S3_COPY_OBJECT_FILE_SIZE_LIMIT:
+                copy_function = cl.copy
+            else:
+                copy_function = cl.copy_object
+            copy_function(
                 CopySource={"Bucket": bucket, "Key": path},
                 Bucket=dest_bucket,
                 Key=dest_path,
@@ -287,9 +295,13 @@ class S3URI(URIBase):
 
     @staticmethod
     def init_s3uri(
-        loc_prefix: Optional[str] = None, duration_presigned_url: Optional[int] = None
+        loc_prefix: Optional[str] = None,
+        duration_presigned_url: Optional[int] = None,
+        s3_copy_object_file_size_limit: Optional[int] = None,
     ):
         if loc_prefix is not None:
             S3URI.LOC_PREFIX = loc_prefix
         if duration_presigned_url is not None:
             S3URI.DURATION_PRESIGNED_URL = duration_presigned_url
+        if s3_copy_object_file_size_limit is not None:
+            S3URI.S3_COPY_OBJECT_FILE_SIZE_LIMIT = s3_copy_object_file_size_limit


### PR DESCRIPTION
- For s3-to-s3 file transfer, use `copy` instead for `copy_object` for larges files >= 5GB
- Better logging: show start/end of `cp` action with UUID of a file.
