### PR TITLE
Pipe 11 expiration for gcs lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,8 @@ install_gcs_lib: &install_gcs_lib
 install_aws_lib: &install_aws_lib
   name: Install AWS Python API (boto3) and CLI (awscli)
   command: |
-    sudo pip3 install boto3 awscli --user
+    sudo pip3 install awscli --user
+    sudo pip3 install boto3
 
 
 make_root_only_dir: &make_root_only_dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ update_apt:
 
 
 install_python3: &install_python3
-  name: Install python3, pip3, java
+  name: Install python3, pip3
   command: |
-    sudo apt-get install -y software-properties-common git wget curl python3 python3-pip default-jre
+    sudo apt-get install -y software-properties-common git wget curl python3 python3-pip
 
 
 install_shellcheck: &install_shellcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,19 +10,21 @@ defaults:
 
 machine_defaults: &machine_defaults
   machine:
-    image: ubuntu-1604:202007-01
+    image: ubuntu-2004:202010-01
   working_directory: ~/autouri
 
 
-install_python3: &install_python3
-  name: Install python3, pip3
+update_apt:
+  name: Update apt
   command: |
-    sudo apt-get update && sudo apt-get install software-properties-common git wget curl -y
-    sudo add-apt-repository ppa:deadsnakes/ppa -y
-    sudo apt-get update && sudo apt-get install python3.6 -y
-    sudo wget https://bootstrap.pypa.io/get-pip.py
-    sudo python3.6 get-pip.py
-    sudo ln -s /usr/bin/python3.6 /usr/local/bin/python3
+    sudo apt-get update -y
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+
+
+install_python3: &install_python3
+  name: Install python3, pip3, java
+  command: |
+    sudo apt-get install -y software-properties-common git wget curl python3 python3-pip default-jre
 
 
 install_shellcheck: &install_shellcheck
@@ -41,8 +43,9 @@ install_precommit: &install_precommit
 install_py3_packages: &install_py3_packages
   name: Install Python packages
   command: |
-    sudo pip3 install pytest requests dateparser filelock "six>=1.13.0"
-    sudo pip3 install --upgrade pyasn1-modules
+    sudo python3 -m pip install --upgrade pip
+    sudo pip3 install PyYAML --ignore-installed
+    sudo pip3 install pytest requests dateparser filelock six ntplib
 
 
 install_gcs_lib: &install_gcs_lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
           no_output_timeout: 60m
           command: |
             cd tests/
-            # sign in
             echo ${GCLOUD_SERVICE_ACCOUNT_SECRET_JSON} > tmp_key.json
             gcloud auth activate-service-account --project=${GOOGLE_PROJECT_ID} --key-file=tmp_key.json
             gcloud config set project ${GOOGLE_PROJECT_ID}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ install_gcs_lib: &install_gcs_lib
 install_aws_lib: &install_aws_lib
   name: Install AWS Python API (boto3) and CLI (awscli)
   command: |
-    sudo pip3 install boto3 awscli
+    sudo pip3 install boto3 awscli --user
 
 
 make_root_only_dir: &make_root_only_dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,19 +33,12 @@ install_shellcheck: &install_shellcheck
     curl -Ls https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz | tar xJ && sudo mv shellcheck-stable/shellcheck /usr/local/bin/
 
 
-install_precommit: &install_precommit
-  name: Install Python pre-commit
-  command: |
-    sudo pip3 install PyYAML --ignore-installed
-    sudo pip3 install pre-commit
-
-
 install_py3_packages: &install_py3_packages
   name: Install Python packages
   command: |
     sudo python3 -m pip install --upgrade pip
     sudo pip3 install PyYAML --ignore-installed
-    sudo pip3 install pytest requests dateparser filelock six ntplib
+    sudo pip3 install pre-commit pytest requests dateparser filelock six ntplib
 
 
 install_gcs_lib: &install_gcs_lib
@@ -76,7 +69,7 @@ jobs:
     steps:
       - checkout
       - run: *install_python3
-      - run: *install_precommit
+      - run: *install_py3_packages
       - run: *install_shellcheck
       - run:
           no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ install_shellcheck: &install_shellcheck
 install_py3_packages: &install_py3_packages
   name: Install Python packages
   command: |
-    sudo python3 -m pip install --upgrade pip
-    sudo pip3 install PyYAML --ignore-installed
-    sudo pip3 install pre-commit pytest requests dateparser filelock six ntplib
+    python3 -m pip install --upgrade pip
+    pip3 install PyYAML --ignore-installed
+    pip3 install pre-commit pytest requests dateparser filelock six ntplib
 
 
 install_gcs_lib: &install_gcs_lib
@@ -47,14 +47,13 @@ install_gcs_lib: &install_gcs_lib
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
     sudo apt-get update && sudo apt-get install google-cloud-sdk -y
-    sudo pip3 install google-cloud-storage
+    pip3 install google-cloud-storage
 
 
 install_aws_lib: &install_aws_lib
   name: Install AWS Python API (boto3) and CLI (awscli)
   command: |
-    sudo pip3 install awscli --user
-    sudo pip3 install boto3
+    pip3 install awscli boto3
 
 
 make_root_only_dir: &make_root_only_dir

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,7 +4,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-known_third_party = boto3,botocore,dateparser,dateutil,filelock,google,pytest,requests,setuptools
+known_third_party = boto3,botocore,dateparser,dateutil,filelock,google,ntplib,pytest,requests,setuptools
 
 [mypy-bin]
 ignore_errors = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
 
   - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.2
@@ -14,7 +14,7 @@
     rev: v4.3.21
     hooks:
       - id: isort
-        language_version: python3.6
+        language_version: python3
 
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: v1.0.6

--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -5,4 +5,4 @@ from .httpurl import HTTPURL
 from .s3uri import S3URI
 
 __all__ = ["AbsPath", "AutoURI", "URIBase", "GCSURI", "HTTPURL", "S3URI"]
-__version__ = "0.2.6"
+__version__ = "0.3.0"

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -139,7 +139,7 @@ class GCSURILock(BaseFileLock):
                 blob, _ = u.get_blob()
 
                 # if lock file already exists then check if it's expired
-                if now_utc().timestamp > metadata.mt + self._lockfile_expiration_sec:
+                if now_utc().timestamp > metadata.mtime + self._lockfile_expiration_sec:
                     logger.debug(
                         "Lock file expired. so will be released and then deleted."
                     )

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -136,21 +136,16 @@ class GCSURILock(BaseFileLock):
             metadata = u.get_metadata()
 
             if metadata.exists:
-                blob, _ = u.get_blob()
-
                 # if lock file already exists then check if it's expired
                 if (
                     now_utc().timestamp()
                     > metadata.mtime + self._lockfile_expiration_sec
                 ):
-                    logger.debug(
-                        "Lock file expired. so will be released and then deleted."
-                    )
-
+                    logger.debug("Found expired lock file, will release/delete it.")
+                    blob, _ = u.get_blob()
                     if blob.temporary_hold:
                         blob.temporary_hold = False
                         blob.patch()
-
                     blob.delete()
                 else:
                     return
@@ -242,7 +237,7 @@ class GCSURI(URIBase):
     DURATION_PRESIGNED_URL: int = 4233600
 
     RETRY_BUCKET: int = 3
-    RETRY_BUCKET_DELAY: int = 1
+    RETRY_BUCKET_DELAY: int = 3
     USE_GSUTIL_FOR_S3: bool = False
 
     _CACHED_GCS_CLIENTS = {}

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -139,7 +139,10 @@ class GCSURILock(BaseFileLock):
                 blob, _ = u.get_blob()
 
                 # if lock file already exists then check if it's expired
-                if now_utc().timestamp > metadata.mtime + self._lockfile_expiration_sec:
+                if (
+                    now_utc().timestamp()
+                    > metadata.mtime + self._lockfile_expiration_sec
+                ):
                     logger.debug(
                         "Lock file expired. so will be released and then deleted."
                     )

--- a/autouri/ntp_now.py
+++ b/autouri/ntp_now.py
@@ -1,0 +1,61 @@
+"""Accurate now() based on cached offset between NTP server
+and local system time.
+
+Make sure not to change system time once the offset is cached.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+import ntplib
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NTP_SERVER = "pool.ntp.org"
+cached_offset_between_ntp_server_and_local_system = None
+
+
+def now_utc(ntp_server=DEFAULT_NTP_SERVER):
+    global cached_offset_between_ntp_server_and_local_system
+
+    if cached_offset_between_ntp_server_and_local_system is not None:
+        return (
+            datetime.now(timezone.utc)
+            + cached_offset_between_ntp_server_and_local_system
+        )
+
+    try:
+        resp = ntplib.NTPClient().request(ntp_server)
+        adjusted_timestamp = resp.tx_time + resp.delay * 0.5
+        ntp_server_time = datetime.fromtimestamp(adjusted_timestamp, timezone.utc)
+        # update cache
+        cached_offset_between_ntp_server_and_local_system = (
+            ntp_server_time - datetime.now(timezone.utc)
+        )
+        logger.debug(
+            "Successfully retrieved time from NTP server {srv}. time:{time}, offset:{offset}".format(
+                srv=ntp_server,
+                time=ntp_server_time,
+                offset=cached_offset_between_ntp_server_and_local_system.total_seconds(),
+            )
+        )
+        return ntp_server_time
+
+    except Exception as e:
+        logger.debug(
+            "Failed to retrieve time from NTP server {srv}. error {err}".format(
+                srv=ntp_server, err=str(e)
+            )
+        )
+
+    return datetime.now(timezone.utc)
+
+
+def reset_cached_offset():
+    global cached_offset_between_ntp_server_and_local_system
+    cached_offset_between_ntp_server_and_local_system = None
+
+
+def get_cached_offset():
+    global cached_offset_between_ntp_server_and_local_system
+    return cached_offset_between_ntp_server_and_local_system

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setuptools.setup(
         "dateparser",
         "filelock",
         "six>=1.13.0",
+        "ntplib",
     ],
 )

--- a/tests/test_ntp_now.py
+++ b/tests/test_ntp_now.py
@@ -19,14 +19,13 @@ class MockedDataTime(datetime):
 
 
 def test_now_utc_wrong_os_time():
-    correct_now = datetime.now(timezone.utc)
-
+    reset_cached_offset()
     with patch("autouri.ntp_now.datetime", MockedDataTime):
-        reset_cached_offset()
+        ntp_now_utc = now_utc()
 
-        # should be accurate even though system time is 25 second behind NTP server time
-        assert abs((now_utc() - correct_now).total_seconds()) < 0.01
+    # should be accurate even though system time is 25 second behind NTP server time
+    assert abs((ntp_now_utc - datetime.now(timezone.utc)).total_seconds()) < 0.01
 
-        # cache offset should be 25 second
-        cached_offset_in_seconds = get_cached_offset().total_seconds()
-        assert cached_offset_in_seconds > 24.99 and cached_offset_in_seconds < 25.01
+    # cache offset should be 25 second
+    cached_offset_in_seconds = get_cached_offset().total_seconds()
+    assert cached_offset_in_seconds > 24.99 and cached_offset_in_seconds < 25.01

--- a/tests/test_ntp_now.py
+++ b/tests/test_ntp_now.py
@@ -1,0 +1,29 @@
+"""Make sure to run these tests on a machine with correct os time
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from autouri.ntp_now import get_cached_offset, now_utc, reset_cached_offset
+
+
+def test_now_utc():
+    reset_cached_offset()
+    assert abs((now_utc() - datetime.now(timezone.utc)).total_seconds()) < 0.01
+
+
+class MockedDataTime(datetime):
+    @classmethod
+    def now(cls, timezone):
+        return datetime.now(timezone) - timedelta(0, 25)
+
+
+def test_now_utc_wrong_os_time():
+    reset_cached_offset()
+
+    with patch("autouri.ntp_now.datetime", MockedDataTime):
+        # should be accurate even though system time is 25 second behind NTP server time
+        assert abs((now_utc() - datetime.now(timezone.utc)).total_seconds()) < 0.01
+
+        # cache offset should be 25 second
+        cached_offset_in_seconds = get_cached_offset().total_seconds()
+        assert cached_offset_in_seconds > 24.99 and cached_offset_in_seconds < 25.01

--- a/tests/test_ntp_now.py
+++ b/tests/test_ntp_now.py
@@ -8,6 +8,7 @@ from autouri.ntp_now import get_cached_offset, now_utc, reset_cached_offset
 
 def test_now_utc():
     reset_cached_offset()
+
     assert abs((now_utc() - datetime.now(timezone.utc)).total_seconds()) < 0.01
 
 
@@ -18,11 +19,13 @@ class MockedDataTime(datetime):
 
 
 def test_now_utc_wrong_os_time():
-    reset_cached_offset()
+    correct_now = datetime.now(timezone.utc)
 
     with patch("autouri.ntp_now.datetime", MockedDataTime):
+        reset_cached_offset()
+
         # should be accurate even though system time is 25 second behind NTP server time
-        assert abs((now_utc() - datetime.now(timezone.utc)).total_seconds()) < 0.01
+        assert abs((now_utc() - correct_now).total_seconds()) < 0.01
 
         # cache offset should be 25 second
         cached_offset_in_seconds = get_cached_offset().total_seconds()

--- a/tests/test_race_cond.py
+++ b/tests/test_race_cond.py
@@ -67,7 +67,7 @@ def test_race_cond_autouri_write_local(local_test_path):
 
 def test_race_cond_autouri_write_gcs(gcs_test_path):
     prefix = os.path.join(gcs_test_path, "test_race_cond_autouri_write_gcs")
-    nth = 20
+    nth = 15
     run_write_v6_txt(prefix, nth)
 
 

--- a/tests/test_race_cond.py
+++ b/tests/test_race_cond.py
@@ -67,7 +67,7 @@ def test_race_cond_autouri_write_local(local_test_path):
 
 def test_race_cond_autouri_write_gcs(gcs_test_path):
     prefix = os.path.join(gcs_test_path, "test_race_cond_autouri_write_gcs")
-    nth = 15
+    nth = 10
     run_write_v6_txt(prefix, nth)
 
 

--- a/tests/test_race_cond.py
+++ b/tests/test_race_cond.py
@@ -67,7 +67,7 @@ def test_race_cond_autouri_write_local(local_test_path):
 
 def test_race_cond_autouri_write_gcs(gcs_test_path):
     prefix = os.path.join(gcs_test_path, "test_race_cond_autouri_write_gcs")
-    nth = 10
+    nth = 20
     run_write_v6_txt(prefix, nth)
 
 


### PR DESCRIPTION
- implemented an accurate cached now function (`utp_now.now_utc()`) based on NTP server response
- for gs:// URIs, if expired (3600 seconds old) lock file exists then release/delete it
