### PR TITLE
v0.4.1

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,7 +4,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-known_third_party = boto3,botocore,dateparser,dateutil,filelock,google,ntp_now,ntplib,pytest,requests,setuptools
+known_third_party = boto3,botocore,dateparser,dateutil,filelock,google,ntplib,pytest,requests,setuptools
 
 [mypy-bin]
 ignore_errors = True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,7 +4,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-known_third_party = boto3,botocore,dateparser,dateutil,filelock,google,ntplib,pytest,requests,setuptools
+known_third_party = boto3,botocore,dateparser,dateutil,filelock,google,ntp_now,ntplib,pytest,requests,setuptools
 
 [mypy-bin]
 ignore_errors = True

--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -5,4 +5,4 @@ from .httpurl import HTTPURL
 from .s3uri import S3URI
 
 __all__ = ["AbsPath", "AutoURI", "URIBase", "GCSURI", "HTTPURL", "S3URI"]
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -94,10 +94,11 @@ class GCSURILock(BaseFileLock):
                 or now_utc().timestamp() > u.mtime + GCSURILock.LOCK_FILE_EXPIRATION_SEC
             ):
                 u.write(str_id, no_lock=True)
-                time.sleep(self._lock_read_delay)
-
-            if u.read() == str_id:
                 self._lock_file_fd = id(self)
+
+            elif u.read() == str_id:
+                self._lock_file_fd = id(self)
+
         except (Forbidden, NotFound):
             raise
         except (ClientError, ValueError):

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -23,10 +23,10 @@ from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import storage
 from google.cloud.storage import Blob
 from google.oauth2.service_account import Credentials
-from ntp_now import now_utc
 
 from .autouri import AutoURI, URIBase
 from .metadata import URIMetadata, get_seconds_from_epoch, parse_md5_str
+from .ntp_now import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -100,7 +100,7 @@ class GCSURILock(BaseFileLock):
                 self._lock_file_fd = id(self)
         except (Forbidden, NotFound):
             raise
-        except ClientError:
+        except (ClientError, ValueError):
             pass
         return None
 

--- a/autouri/s3uri.py
+++ b/autouri/s3uri.py
@@ -2,7 +2,6 @@
     S3 Object versioning must be turned off
 """
 import logging
-import time
 from tempfile import NamedTemporaryFile
 from typing import Optional, Tuple
 
@@ -59,10 +58,11 @@ class S3URILock(BaseFileLock):
                 or now_utc().timestamp() > u.mtime + S3URILock.LOCK_FILE_EXPIRATION_SEC
             ):
                 u.write(str_id, no_lock=True)
-                time.sleep(self._lock_read_delay)
-
-            if u.read() == str_id:
                 self._lock_file_fd = id(self)
+
+            elif u.read() == str_id:
+                self._lock_file_fd = id(self)
+
         except ClientError as e:
             status = e.response["ResponseMetadata"]["HTTPStatusCode"]
             if status in (403, 404):

--- a/autouri/s3uri.py
+++ b/autouri/s3uri.py
@@ -10,10 +10,10 @@ import requests
 from boto3 import client
 from botocore.exceptions import ClientError
 from filelock import BaseFileLock
-from ntp_now import now_utc
 
 from .autouri import AutoURI, URIBase
 from .metadata import URIMetadata, get_seconds_from_epoch, parse_md5_str
+from .ntp_now import now_utc
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Make lockfile of `GCSURI` and `S3URI` expire (defined as class constants)
- `S3URILock.LOCK_FILE_EXPIRATION_SEC`: `1800` by default (in seconds)
- `GCSURILock.LOCK_FILE_EXPIRATION_SEC`: `1800` by default (in seconds)
