### PR TITLE
Hotfix upgrade filelock

### DIFF
--- a/autouri/__init__.py
+++ b/autouri/__init__.py
@@ -5,4 +5,4 @@ from .httpurl import HTTPURL
 from .s3uri import S3URI
 
 __all__ = ["AbsPath", "AutoURI", "URIBase", "GCSURI", "HTTPURL", "S3URI"]
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/autouri/gcsuri.py
+++ b/autouri/gcsuri.py
@@ -86,7 +86,7 @@ class GCSURILock(BaseFileLock):
         """Unlike GCSURI, this module does not use S3 Object locking.
         This will write id(self) on a .lock file.
         """
-        u = GCSURI(self._lock_file)
+        u = GCSURI(self.lock_file)
         str_id = str(id(self))
         try:
             if (
@@ -94,10 +94,10 @@ class GCSURILock(BaseFileLock):
                 or now_utc().timestamp() > u.mtime + GCSURILock.LOCK_FILE_EXPIRATION_SEC
             ):
                 u.write(str_id, no_lock=True)
-                self._lock_file_fd = id(self)
+                self._context.lock_file_fd = id(self)
 
             elif u.read() == str_id:
-                self._lock_file_fd = id(self)
+                self._context.lock_file_fd = id(self)
 
         except Forbidden:
             raise
@@ -109,10 +109,10 @@ class GCSURILock(BaseFileLock):
         return None
 
     def _release(self):
-        u = GCSURI(self._lock_file)
+        u = GCSURI(self.lock_file)
         try:
             u.rm(no_lock=True, silent=True)
-            self._lock_file_fd = None
+            self._context.lock_file_fd = None
         except (ClientError, ValueError):
             pass
         return None

--- a/autouri/s3uri.py
+++ b/autouri/s3uri.py
@@ -50,7 +50,7 @@ class S3URILock(BaseFileLock):
         """Unlike GCSURI, this module does not use S3 Object locking.
         This will write id(self) on a .lock file.
         """
-        u = S3URI(self._lock_file)
+        u = S3URI(self.lock_file)
         str_id = str(id(self))
         try:
             if (
@@ -58,10 +58,10 @@ class S3URILock(BaseFileLock):
                 or now_utc().timestamp() > u.mtime + S3URILock.LOCK_FILE_EXPIRATION_SEC
             ):
                 u.write(str_id, no_lock=True)
-                self._lock_file_fd = id(self)
+                self._context.lock_file_fd = id(self)
 
             elif u.read() == str_id:
-                self._lock_file_fd = id(self)
+                self._context.lock_file_fd = id(self)
 
         except ClientError as e:
             status = e.response["ResponseMetadata"]["HTTPStatusCode"]
@@ -73,10 +73,10 @@ class S3URILock(BaseFileLock):
         return None
 
     def _release(self):
-        u = S3URI(self._lock_file)
+        u = S3URI(self.lock_file)
         try:
             u.rm(no_lock=True, silent=True)
-            self._lock_file_fd = None
+            self._context.lock_file_fd = None
         except ClientError:
             pass
         return None

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setuptools.setup(
         "boto3",
         "awscli",
         "dateparser",
-        "filelock>=3.4.0",
+        "filelock>=3.12.0",
         "six>=1.13.0",
         "ntplib",
     ],


### PR DESCRIPTION
`py-filelock` deprecated some methods in the latest release 3.12.0.
This PR is a hotfix for them.
